### PR TITLE
fix: copy destination should include assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN mkdir -p /tmp/nginx/client-body
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY src/public /usr/share/nginx/html
-COPY vendor/lightbox-2.6/css/* /usr/share/nginx/html/css/
-COPY vendor/lightbox-2.6/js/* /usr/share/nginx/html/js/
-COPY vendor/lightbox-2.6/img/* /usr/share/nginx/html/img/
+COPY vendor/lightbox-2.6/css/* /usr/share/nginx/html/assets/css/
+COPY vendor/lightbox-2.6/js/* /usr/share/nginx/html/assets/js/
+COPY vendor/lightbox-2.6/img/* /usr/share/nginx/html/assets/img/
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
I did not notice lightbox failing on local builds because I had ignored
files added to my own assets dir from a previous build scheme.
